### PR TITLE
adding basic group security setup to add group members from users tabel

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ class MainHandler(webapp2.RequestHandler):
 
         current_user = users.get_current_user()
         values = {}
-        
+
         if current_user:
             values["logout_url"] = users.create_logout_url('/')
             user = User.all().filter('user_id =', current_user.user_id()).get()
@@ -54,7 +54,7 @@ class MainHandler(webapp2.RequestHandler):
                 user.name = str(current_user)
                 user.user_id = current_user.user_id()
                 user.put()
-            
+
             token = channel.create_channel(user.user_id)
 
             values["user"] = user
@@ -69,6 +69,17 @@ class MainHandler(webapp2.RequestHandler):
         template = JINJA_ENVIRONMENT.get_template('src/index.html')
         self.response.write(template.render(values))
 
+class UserList(webapp2.RequestHandler):
+    def get(self):
+
+        values = []
+        _users = User.all().fetch(100)
+        for user in _users:
+            values.append(user.serializable());
+
+        self.response.headers['Content-Type'] = 'application/json'
+        self.response.out.write(json.dumps(values))
+
 class GroupCreate(webapp2.RequestHandler):
     def post(self):
         data = json.loads(self.request.body)
@@ -76,13 +87,13 @@ class GroupCreate(webapp2.RequestHandler):
         group = Group()
         group.name = data.get('name')
         group.put()
-        
+
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps(group.serializable()))
 
 class GroupList(webapp2.RequestHandler):
     def get(self):
-        
+
         values = []
         _groups= Group.all().fetch(100)
         for group in _groups:
@@ -95,7 +106,7 @@ class GroupUpdate(webapp2.RequestHandler):
     def post(self, group_key):
         data = json.loads(self.request.body)
         group = Group.get(group_key)
-        
+
         group.story = data.get('story')
         group.notes = data.get('notes')
         group.put()
@@ -103,21 +114,51 @@ class GroupUpdate(webapp2.RequestHandler):
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps({"success": True}))
 
+class GroupAddMember(webapp2.RequestHandler):
+    def post(self, group_key):
+        logging.info(self.request.body)
+        data = json.loads(self.request.body)
+
+        group = Group.get(group_key)
+
+        try:
+            member = db.Query(User).filter('name', data.get('name'))[0]
+        except:
+            member = None
+
+        if member and (group.key() not in member.groups):
+            member.groups.append(group.key())
+            member.put()
+
+        self.response.headers['Content-Type'] = 'application/json'
+        self.response.out.write(json.dumps(member.serializable()))
+
+class GroupDeleteMember(webapp2.RequestHandler):
+    def post(self, group_key, member_key):
+        group = Group.get(group_key)
+        member = User.get(member_key)
+
+        member.groups.remove(group.key())
+        member.put()
 
 class SetDungeonMaster(webapp2.RequestHandler):
     def post(self, group_key):
 
         data = json.loads(self.request.body)
 
-        user = User.all().filter('user_id =', data.get('user_id')).get()
+        user = User.get(data.get('user_key'))
         group = Group.get(group_key)
-        
+
+        logging.info('userid: ' + data.get('user_key') + ', username: ' + user.name)
+
         group.dm = user
         group.put()
-        
+
         values = {
             'info': 'dm set'
         }
+
+        logging.info('group dm: ' + group.dm.name)
 
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps(values))
@@ -126,7 +167,7 @@ class GroupDetail(webapp2.RequestHandler):
     def get(self, group_key):
         group = Group.get(group_key)
         players = []
-        
+
         for player in group.players:
             players.append(player.serializable())
 
@@ -160,9 +201,9 @@ class CharacterDelete(webapp2.RequestHandler):
 
 class CharacterCreate(webapp2.RequestHandler):
     def post(self):
-        
+
         data = json.loads(self.request.body)
-        
+
         if users.get_current_user():
             character = Character()
             character.name = data.get('name')
@@ -173,7 +214,7 @@ class CharacterCreate(webapp2.RequestHandler):
             values = {
                 'character': character.serializable()
             }
-            
+
             self.response.headers['Content-Type'] = 'application/json'
             self.response.out.write(json.dumps(values))
         else:
@@ -204,8 +245,8 @@ class AvatarUpload(webapp2.RequestHandler):
 class CharacterUpdate(webapp2.RequestHandler):
     def post(self, character_key):
         data = json.loads(self.request.body)
-        char_data = data.get('character') 
-        channel_token = data.get('channel_token') 
+        char_data = data.get('character')
+        channel_token = data.get('channel_token')
         character = Character.get(character_key)
         values = {}
 
@@ -229,8 +270,8 @@ class CharacterUpdate(webapp2.RequestHandler):
                 setattr(character, k, value)
             except Exception, e:
                 logging.exception(e)
-        
-        try:                 
+
+        try:
             character.put()
             values = character.serializable()
 
@@ -241,7 +282,7 @@ class CharacterUpdate(webapp2.RequestHandler):
 
             for player in group.players:
                 channel.send_message(player.user.user_id(), json.dumps(message))
-            
+
             if group.dm:
                 channel.send_message(group.dm.user_id, json.dumps(message))
 
@@ -316,7 +357,7 @@ class CharacterAddWeapon(webapp2.RequestHandler):
     def post(self, character_key):
         logging.info(self.request.body)
         data = json.loads(self.request.body)
-        
+
         weapon = Weapon()
         weapon.character = Character.get(character_key)
         weapon.json_string = unicode(self.request.body, 'utf-8');
@@ -361,11 +402,14 @@ app = webapp2.WSGIApplication([
     ('/', MainHandler),
     ('/images/?', Image),
     ('/api/v1/character/create/?', CharacterCreate),
+    ('/api/v1/users/list/?', UserList),
     ('/api/v1/groups/create/?', GroupCreate),
     ('/api/v1/groups/list/?', GroupList),
     ('/api/v1/groups/(?P<group_key>[^/]+)/?', GroupDetail),
     ('/api/v1/groups/(?P<group_key>[^/]+)/update/?', GroupUpdate),
     ('/api/v1/groups/(?P<group_key>[^/]+)/dm/?', SetDungeonMaster),
+    ('/api/v1/groups/(?P<group_key>[^/]+)/members/add?/', GroupAddMember),
+    ('/api/v1/groups/(?P<group_key>[^/]+)/members/(?P<member_key>[^/]+)/delete/?', GroupDeleteMember),
     ('/api/v1/character/(?P<character_key>[^/]+)/?', CharacterDetail),
     ('/api/v1/character/(?P<character_key>[^/]+)/update/?', CharacterUpdate),
     ('/api/v1/character/(?P<character_key>[^/]+)/delete/?', CharacterDelete),
@@ -377,6 +421,6 @@ app = webapp2.WSGIApplication([
     ('/api/v1/character/(?P<character_key>[^/]+)/weapons/add/?', CharacterAddWeapon),
     ('/api/v1/character/(?P<character_key>[^/]+)/weapons/(?P<weapon_key>[^/]+)/update/?', CharacterUpdateWeapon),
     ('/api/v1/character/(?P<character_key>[^/]+)/weapons/(?P<weapon_key>[^/]+)/delete/?', CharacterDeleteWeapon),
-    
+
 
 ], debug=True)

--- a/models.py
+++ b/models.py
@@ -6,7 +6,9 @@ class User(db.Model):
     user_id = db.StringProperty()
     name = db.StringProperty()
     is_admin = db.BooleanProperty(default=False)
-    
+
+    groups = db.ListProperty(db.Key)
+
     def serializable(self):
         result = {}
         result["key"] = str(self.key())
@@ -19,18 +21,30 @@ class Group(db.Model):
     name = db.StringProperty()
     story = db.TextProperty()
     notes = db.TextProperty()
+
     dm = db.ReferenceProperty(User, default=None)
-    
+
+    @property
+    def members(self):
+        return User.gql("WHERE groups = :1", self.key())
+
     def serializable(self):
+        _members = []
+        for member in self.members:
+            _members.append(member.serializable())
+
         values = {
             'date_created': self.date_created.isoformat(),
             'key': str(self.key()),
             'name': self.name,
             'story': self.story,
-            'notes': self.notes
+            'notes': self.notes,
+            'members': _members
         }
+
         if self.dm:
             values['dm'] = self.dm.serializable()
+
         return values
 
 
@@ -55,30 +69,30 @@ class Character(db.Model):
     deity = db.StringProperty()
     affiliations = db.StringProperty()
     avatar = db.BlobProperty(default=None)
-    
+
     # Initiative
     initiative_score = db.IntegerProperty(default=0)
     initiative_misc = db.IntegerProperty(default=0)
-    
+
     # Ability Scores
     strength = db.IntegerProperty(default=0)
     strength_abil_mod = db.IntegerProperty(default=0)
-    
+
     constitution = db.IntegerProperty(default=0)
     constitution_abil_mod = db.IntegerProperty(default=0)
-    
+
     dexterity = db.IntegerProperty(default=0)
     dexterity_abil_mod = db.IntegerProperty(default=0)
-    
+
     intelligence = db.IntegerProperty(default=0)
     intelligence_abil_mod = db.IntegerProperty(default=0)
-    
+
     wisdom = db.IntegerProperty(default=0)
     wisdom_abil_mod = db.IntegerProperty(default=0)
-    
+
     charisma = db.IntegerProperty(default=0)
     charisma_abil_mod = db.IntegerProperty(default=0)
-    
+
 
     # Defenses
     armor_class_total = db.IntegerProperty(default=0)
@@ -261,30 +275,30 @@ class Character(db.Model):
             'deity': self.deity,
             'affiliations': self.affiliations,
             'avatar_url': self.get_avatar_url(),
-            
+
             # Initiative
             'initiative_score': self.initiative_score,
             'initiative_misc': self.initiative_misc,
-            
+
             # Ability Scores
             'strength': self.strength,
             'strength_abil_mod': self.strength_abil_mod,
-            
+
             'constitution': self.constitution,
             'constitution_abil_mod': self.constitution_abil_mod,
-            
+
             'dexterity': self.dexterity,
             'dexterity_abil_mod': self.dexterity_abil_mod,
-            
+
             'intelligence': self.intelligence,
             'intelligence_abil_mod': self.intelligence_abil_mod,
-            
+
             'wisdom': self.wisdom,
             'wisdom_abil_mod': self.wisdom_abil_mod,
-            
+
             'charisma': self.charisma,
             'charisma_abil_mod': self.charisma_abil_mod,
-            
+
 
             # Defenses
             'armor_class_total': self.armor_class_total,
@@ -438,7 +452,7 @@ class Power(db.Model):
     json_string = db.TextProperty()
 
     def serializable(self):
-        payload = json.loads(self.json_string) 
+        payload = json.loads(self.json_string)
         payload['key'] = str(self.key())
 
         return payload
@@ -451,7 +465,7 @@ class Weapon(db.Model):
     damage = db.StringProperty()
 
     def serializable(self):
-        payload = json.loads(self.json_string) 
+        payload = json.loads(self.json_string)
         payload['key'] = str(self.key())
         payload['attack'] = self.attack
         payload['defense'] = self.defense
@@ -464,7 +478,7 @@ class Item(db.Model):
     json_string = db.TextProperty()
 
     def serializable(self):
-        payload = json.loads(self.json_string) 
+        payload = json.loads(self.json_string)
         payload['key'] = str(self.key())
 
         return payload

--- a/src/partials/group-detail.admin.html
+++ b/src/partials/group-detail.admin.html
@@ -1,16 +1,70 @@
 <div class="content-view">
 	<div class="row">
-		<div class="columns medium-12">
-			<h2>Admin</h2>
+		<div class="columns medium-6">
 
-			<div><strong>Dungeon Master:</strong> {{ group.dm.name }}</div>
+			<h2>Dungeon Master</h2>
 
-			<div ng-repeat="character in characters">
-				<div>{{character.name }} -- {{ character.user_name }} | <a ng-click="delete_character()">delete</a> | <a ng-click="set_dm(character.user_id)"> make dm</a></div>
-			</div>
+			<ul class="member-list" dnd-list="members">
+          <li class="dm card">
+						<div class="toolbar">
+								<div class="avatar micro default">
+									<span>{{ group.dm.name[0] }}</span>
+								</div>
+								<h1>{{ group.dm.name }}</h1>
+								<p class="char-bio">
+			              Motherfucking Master of the Universe
+			          </p>
+				    </div>
+          </li>
+      </ul>
 
-			<h2>Invite</h2>
-			<p>Soon...</p>
+
+			<h2>Group Members</h2>
+
+			<ul class="member-list" dnd-list="members">
+          <li class="member card" ng-repeat="member in group.members">
+						<div class="toolbar">
+								<div class="avatar micro default">
+									<span>{{ member.name[0] }}</span>
+								</div>
+								<h1>{{ member.name }}</h1>
+
+	          		<i class="fa fa-trash" ng-click="delete_member(member.id)"></i> | <i class="fa fa-magic" ng-click="set_dm(member.key)"></i>
+				    </div>
+          </li>
+
+          <li class="member">
+						<input type="text" ng-model="new_member" typeahead="member as member.name for member in userlist | filter:{name:$viewValue} | limitTo:20" class="width-100">
+						<button ng-click="add_member()" class="width-100">add</button>
+          </li>
+      </ul>
+
+		</div>
+
+		<div class="columns medium-6">
+			<h2>Group Party</h2>
+
+			<ul class="characters" dnd-list="characters">
+				<li class="character-card--admin card" ng-repeat="character in characters">
+					<div class="toolbar">
+						<a ui-sref="character-detail.advanced({character_key: character.key})">
+							<div ng-if="character.avatar_url && character.avatar_url !== 'None'" class="avatar micro" style="background-image: url('{{character.avatar_url}}')"></div>
+							<div ng-if="!character.avatar_url || character.avatar_url === 'None'" class="avatar micro default">
+								<span>{{character.name[0]}}</span>
+							</div>
+							<h1>{{ character.name }}</h1>
+							<p class="char-bio">
+	                A level {{character.level}} {{character.char_race || 'noob'}} {{character.char_class}}
+	            </p>
+			      </a>
+
+          	<i class="fa fa-trash" ng-click="delete_character()"></i>
+			    </div>
+				</li>
+			</ul>
 		</div>
 	</div>
 </div>
+
+
+<!--  -->

--- a/src/partials/group-detail.html
+++ b/src/partials/group-detail.html
@@ -7,7 +7,7 @@
 		<a ng-class="{active: state.current.name === 'group-detail.dashboard'}" ui-sref="group-detail.dashboard">Dashboard</a>
 		<a ng-class="{active: state.current.name === 'group-detail.encounter'}" ui-sref="group-detail.encounter">Encounter</a>
 		<a ng-class="{active: state.current.name === 'group-detail.story'}" ui-sref="group-detail.story">Story</a>
-		<a ng-if="is_admin" ng-class="{active: state.current.name === 'group-detail.admin'}" ui-sref="group-detail.admin">Admin</a>
+		<a ng-class="{active: state.current.name === 'group-detail.admin'}" ui-sref="group-detail.admin">Admin</a>
 	</div>
 </div>
 


### PR DESCRIPTION
took out the admin checks on the admin page for now - going to shift the security so that anyone in the group can 'admin' the group
so as long as there are players in the system, from the group admin you can add them as members
adding DM now works from the user list instead of the char list, so the DM user won't need a character setup
type-ahead on the user member add works 
